### PR TITLE
Add confidence scores to metadata

### DIFF
--- a/oas3.yaml
+++ b/oas3.yaml
@@ -820,6 +820,28 @@ components:
             - single
             - complex
           example: single
+        confidenceType:
+          type: string
+          description: >
+            Type of the confidence measure. This is required for  theoretical
+            models.
+          example: QMEANDisCo
+          enum:
+            - pLDDT
+            - QMEANDisCo
+        confidenceVersion:
+          type: string
+          description: >
+            Version of confidence measure software used to calculate quality. 
+            This is required for theoretical models.
+          example: v1.0.2
+        confidenceAvgLocalScore:
+          type: number
+          description: >
+            Average of the confidence measures in the range of [0,1] for QMEANDisCo 
+            and [0,100] for pLDDT. Please contact 3D-Beacons developers if other 
+            estimates are to be added. This is required for theoretical models.
+          example: 0.95
       required:
         - mappingAccession
         - mappingAccessionType
@@ -827,3 +849,5 @@ components:
         - end
         - modelCategory
         - modelType
+        - confidenceType
+        - confidenceAvgLocalScore


### PR DESCRIPTION
I wasn't aware that the client metadata schema was specified here, but seeing as it is - I've added some fields relating to confidence scores (these are required fields in the main schema so we need to pull them in).